### PR TITLE
Lint all style paths

### DIFF
--- a/bin/mapbox-gl-style-lint
+++ b/bin/mapbox-gl-style-lint
@@ -31,23 +31,24 @@ const { filepaths } = parseArguments(process.argv);
 
 let errors = [];
 
-filepaths.forEach(file => {
-  fs.readFile(file, 'utf8', (err, data) => {
-    if (err) {
-      console.error(err);
-      process.exit(1);
-    }
+filepaths.map(file => {
+  let style;
+  try {
+    style = fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
 
-    // Use jsonlint to get line numbers
-    const style = jsonlint.parse(data);
+  // Use jsonlint to get line numbers
+  style = jsonlint.parse(style);
 
-    let styleErrors = lint(style);
+  let styleErrors = lint(style);
 
-    if (styleErrors) {
-      styleErrors = styleErrors.map(e => getErrorOutput(file, e));
-      errors = errors.concat(styleErrors);
-    }
-  });
+  if (styleErrors) {
+    styleErrors = styleErrors.map(e => getErrorOutput(file, e));
+    errors = errors.concat(styleErrors);
+  }
 });
 
 if (errors.length) {

--- a/bin/mapbox-gl-style-lint
+++ b/bin/mapbox-gl-style-lint
@@ -21,15 +21,15 @@ Usage: ${process.argv[1]} files...`);
   }
 
   return { filepaths };
-}
+};
 
-const outputErrors = (file, errors) => {
-  errors.forEach(e => {
-    console.log(`${file}:${e.line}: ${e.message}`);
-  });
-}
+const getErrorOutput = (file, error) => {
+  return `${file}:${error.line}: ${error.message}`;
+};
 
 const { filepaths } = parseArguments(process.argv);
+
+let errors = [];
 
 filepaths.forEach(file => {
   fs.readFile(file, 'utf8', (err, data) => {
@@ -41,11 +41,16 @@ filepaths.forEach(file => {
     // Use jsonlint to get line numbers
     const style = jsonlint.parse(data);
 
-    const errors = lint(style);
+    let styleErrors = lint(style);
 
-    if (errors) {
-      outputErrors(file, errors);
-      process.exit(1);
+    if (styleErrors) {
+      styleErrors = styleErrors.map(e => getErrorOutput(file, e));
+      errors = errors.concat(styleErrors);
     }
   });
 });
+
+if (errors.length) {
+  errors.forEach(e => console.log(e));
+  process.exit(1);
+}


### PR DESCRIPTION
This changes the logic to show validation errors for all styles.

Previous behavior exited early on finding a single error.

This will be more helpful for linting output so users can fix all errors at once.

Once this merges, let's release and update [lint-mapbox-gl-action](https://github.com/stamen/lint-mapbox-gl-style-action/blob/main/action.yml#L20).